### PR TITLE
Restrict item drop on player join to operators only

### DIFF
--- a/src/main/kotlin/dev/slne/surf/elytra/listeners/ListenerManager.kt
+++ b/src/main/kotlin/dev/slne/surf/elytra/listeners/ListenerManager.kt
@@ -35,6 +35,9 @@ object ListenerManager : Listener {
 
     @EventHandler
     fun onPlayerJoin(event: PlayerJoinEvent) {
+        if (!event.player.isOp) {
+            return
+        }
         MobItemDrop.entries.forEach {
             event.player.inventory.addItem(it.itemStack)
         }


### PR DESCRIPTION
why you should give all players the items when they join?